### PR TITLE
Using TCK Tested JDK builds of OpenJDK  in GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,8 +10,11 @@ on:
     branches: [ master ]
 
 jobs:
-
   build:
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+        java-version: [ 14 ]  
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -19,8 +22,8 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v2.3.0
         with:
-          java-version: 14
-          distribution: 'adopt'
+          java-version: ${{ matrix.java-version }}
+          distribution: 'zulu'
 
       - name: Cache
         uses: actions/cache@v2.1.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       matrix:
         os: [ ubuntu-latest ]
         java-version: [ 14 ]  
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK.